### PR TITLE
HAM: Add MCP config for editor integration

### DIFF
--- a/.codex/config.json
+++ b/.codex/config.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "ham-memory": {
-      "url": "https://goham.dev/api/mcp/9d4081b6-2e17-4b6b-a087-9c329e0e5b82?token=ham_91ce03f999f2cfb0a309a0763f4c067a"
+      "url": "https://goham.dev/api/mcp/9d4081b6-2e17-4b6b-a087-9c329e0e5b82?token=ham_019994032adf294018888f9d19be2bdc"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "type": "streamable-http",
       "url": "https://goham.dev/api/mcp/9d4081b6-2e17-4b6b-a087-9c329e0e5b82",
       "headers": {
-        "Authorization": "Bearer ham_91ce03f999f2cfb0a309a0763f4c067a"
+        "Authorization": "Bearer ham_019994032adf294018888f9d19be2bdc"
       }
     }
   }


### PR DESCRIPTION
## MCP Configuration
This PR adds MCP (Model Context Protocol) config files so your AI editor
can connect to this repo's HAM memory server automatically.
### Files
- `.mcp.json`
- `.codex/config.json`
### What each file does
- **`.mcp.json`** — Claude Code picks this up from the project root. The `ham-memory` MCP server gives Claude access to all HAM tools.
- **`.codex/config.json`** — Codex reads this from the project root. The `ham-memory` entry connects Codex to the HAM API.
### After merging
1. Pull the latest changes
2. Open the project in your editor — it will discover the MCP server automatically
3. Your AI assistant now has access to HAM memory tools
---
*Generated by [HAM](https://ham.dev)*